### PR TITLE
remove non alpha numeric chars in env name as model param

### DIFF
--- a/R/nasaPowerExtraction.R
+++ b/R/nasaPowerExtraction.R
@@ -212,7 +212,7 @@ summaryWeather <- function(object, wide=FALSE){
 
     out <- cbind(out,Z)
     # colnames(out) <- gsub("[[:punct:]]", "", colnames(out) )
-    colnames(out) <- gsub(" ","",colnames(out))
+    colnames(out) <- gsub("[^[:alnum:]]", "", colnames(out))
     out <- out[,-1]
   }
 

--- a/R/prepostmetLMMsolver.R
+++ b/R/prepostmetLMMsolver.R
@@ -54,7 +54,7 @@ postmetLMMsolver <- function(phenoDTfile= NULL, analysisId=NULL,
       if(any(grepl(":designation|designation:", gxeTerms))){
         gxeTermsF <- gxeTerms[which(grepl(":designation|designation:", gxeTerms))]
         for(j in 1:length(envUsed)){
-          pred[which(pred$analysisId == analysisId & pred$effectType %in% gxeTermsF & grepl(gsub("[^[:alnum:]]", "", envUsed[j]), pred$designation)),"environment"] <- envUsed[j]
+          pred[which(pred$analysisId == analysisId & pred$effectType %in% gxeTermsF & grepl(envUsed[j], pred$designation)),"environment"] <- envUsed[j]
         }
       }
     }

--- a/R/prepostmetLMMsolver.R
+++ b/R/prepostmetLMMsolver.R
@@ -38,7 +38,7 @@ premetLMMsolver <- function(phenoDTfile= NULL, fixedTerm= NULL, randomTerm=NULL)
 postmetLMMsolver <- function(phenoDTfile= NULL, analysisId=NULL, 
                              gxeModelNum=NULL, gxeTerms=NULL){
   
-  envUsed <- unique(phenoDTfile$data$pheno[,phenoDTfile$metadata$pheno[which(phenoDTfile$metadata$pheno$parameter == "environment"),"value"]])
+  envUsed <- gsub("[^[:alnum:]]", "", unique(phenoDTfile$data$pheno[,phenoDTfile$metadata$pheno[which(phenoDTfile$metadata$pheno$parameter == "environment"),"value"]]))
   traitUsed <- unique(phenoDTfile$metadata$pheno[which( phenoDTfile$metadata$pheno$parameter == "trait"),"value"])
   
   pred <- phenoDTfile$predictions

--- a/R/prepostmetLMMsolver.R
+++ b/R/prepostmetLMMsolver.R
@@ -39,7 +39,7 @@ postmetLMMsolver <- function(phenoDTfile= NULL, analysisId=NULL,
                              gxeModelNum=NULL, gxeTerms=NULL){
   
   envUsed <- gsub("[^[:alnum:]]", "", unique(phenoDTfile$data$pheno[,phenoDTfile$metadata$pheno[which(phenoDTfile$metadata$pheno$parameter == "environment"),"value"]]))
-  traitUsed <- unique(phenoDTfile$metadata$pheno[which( phenoDTfile$metadata$pheno$parameter == "trait"),"value"])
+  traitUsed <- gsub("[^[:alnum:]]", "", unique(phenoDTfile$metadata$pheno[which( phenoDTfile$metadata$pheno$parameter == "trait"),"value"]))
   
   pred <- phenoDTfile$predictions
   if(gxeModelNum !=0){

--- a/R/prepostmetLMMsolver.R
+++ b/R/prepostmetLMMsolver.R
@@ -7,8 +7,8 @@ premetLMMsolver <- function(phenoDTfile= NULL, fixedTerm= NULL, randomTerm=NULL)
                               "environment:designation", "designation:environment"),
                   "gxeDMD" = c(paste0("env",envUsed,"_designation"), paste0("designation_env",envUsed),
                                paste0("env",envUsed,":designation"), paste0("designation:env",envUsed)),
-                  "gxeFW" = c(paste0("value_",traitUsed,"envIndex_designation"),paste0("designation_value_",traitUsed,"envIndex"),
-                              paste0("value_",traitUsed,"envIndex:designation"),paste0("designation:value_",traitUsed,"envIndex")))
+                  "gxeFW" = c(paste0("value",traitUsed,"envIndex_designation"),paste0("designation_value",traitUsed,"envIndex"),
+                              paste0("value",traitUsed,"envIndex:designation"),paste0("designation:value",traitUsed,"envIndex")))
   
   modelTerms <- c(unlist(lapply(fixedTerm, function(x){paste(x, collapse = ":")})),
                   unlist(lapply(randomTerm, function(x){paste(x, collapse = "_")})))

--- a/R/prepostmetLMMsolver.R
+++ b/R/prepostmetLMMsolver.R
@@ -1,7 +1,7 @@
 premetLMMsolver <- function(phenoDTfile= NULL, fixedTerm= NULL, randomTerm=NULL){
   
   envUsed <- gsub("[^[:alnum:]]", "", unique(phenoDTfile$data$pheno[,phenoDTfile$metadata$pheno[which(phenoDTfile$metadata$pheno$parameter == "environment"),"value"]]))
-  traitUsed <- unique(phenoDTfile$metadata$pheno[which( phenoDTfile$metadata$pheno$parameter == "trait"),"value"])
+  traitUsed <- gsub("[^[:alnum:]]", "", unique(phenoDTfile$metadata$pheno[which( phenoDTfile$metadata$pheno$parameter == "trait"),"value"]))
   
   gxeList <- list("gxeCS" = c("environment_designation", "designation_environment",
                               "environment:designation", "designation:environment"),

--- a/R/prepostmetLMMsolver.R
+++ b/R/prepostmetLMMsolver.R
@@ -38,8 +38,8 @@ premetLMMsolver <- function(phenoDTfile= NULL, fixedTerm= NULL, randomTerm=NULL)
 postmetLMMsolver <- function(phenoDTfile= NULL, analysisId=NULL, 
                              gxeModelNum=NULL, gxeTerms=NULL){
   
-  envUsed <- gsub("[^[:alnum:]]", "", unique(phenoDTfile$data$pheno[,phenoDTfile$metadata$pheno[which(phenoDTfile$metadata$pheno$parameter == "environment"),"value"]]))
-  traitUsed <- gsub("[^[:alnum:]]", "", unique(phenoDTfile$metadata$pheno[which( phenoDTfile$metadata$pheno$parameter == "trait"),"value"]))
+  envUsed <- unique(phenoDTfile$data$pheno[,phenoDTfile$metadata$pheno[which(phenoDTfile$metadata$pheno$parameter == "environment"),"value"]])
+  traitUsed <- unique(phenoDTfile$metadata$pheno[which( phenoDTfile$metadata$pheno$parameter == "trait"),"value"])
   
   pred <- phenoDTfile$predictions
   if(gxeModelNum !=0){

--- a/R/prepostmetLMMsolver.R
+++ b/R/prepostmetLMMsolver.R
@@ -1,6 +1,6 @@
 premetLMMsolver <- function(phenoDTfile= NULL, fixedTerm= NULL, randomTerm=NULL){
   
-  envUsed <- unique(phenoDTfile$data$pheno[,phenoDTfile$metadata$pheno[which(phenoDTfile$metadata$pheno$parameter == "environment"),"value"]])
+  envUsed <- gsub("[^[:alnum:]]", "", unique(phenoDTfile$data$pheno[,phenoDTfile$metadata$pheno[which(phenoDTfile$metadata$pheno$parameter == "environment"),"value"]]))
   traitUsed <- unique(phenoDTfile$metadata$pheno[which( phenoDTfile$metadata$pheno$parameter == "trait"),"value"])
   
   gxeList <- list("gxeCS" = c("environment_designation", "designation_environment",
@@ -38,7 +38,7 @@ premetLMMsolver <- function(phenoDTfile= NULL, fixedTerm= NULL, randomTerm=NULL)
 postmetLMMsolver <- function(phenoDTfile= NULL, analysisId=NULL, 
                              gxeModelNum=NULL, gxeTerms=NULL){
   
-  envUsed <- unique(phenoDTfile$data$pheno[,phenoDTfile$metadata$pheno[which(phenoDTfile$metadata$pheno$parameter == "environment"),"value"]])
+  envUsed <- gsub("[^[:alnum:]]", "", unique(phenoDTfile$data$pheno[,phenoDTfile$metadata$pheno[which(phenoDTfile$metadata$pheno$parameter == "environment"),"value"]]))
   traitUsed <- unique(phenoDTfile$metadata$pheno[which( phenoDTfile$metadata$pheno$parameter == "trait"),"value"])
   
   pred <- phenoDTfile$predictions

--- a/R/prepostmetLMMsolver.R
+++ b/R/prepostmetLMMsolver.R
@@ -38,7 +38,10 @@ premetLMMsolver <- function(phenoDTfile= NULL, fixedTerm= NULL, randomTerm=NULL)
 postmetLMMsolver <- function(phenoDTfile= NULL, analysisId=NULL, 
                              gxeModelNum=NULL, gxeTerms=NULL){
   
-  envUsed <- gsub("[^[:alnum:]]", "", unique(phenoDTfile$data$pheno[,phenoDTfile$metadata$pheno[which(phenoDTfile$metadata$pheno$parameter == "environment"),"value"]]))
+  print(gxeModelNum)
+  print(gxeTerms)
+  
+  envUsed <- unique(phenoDTfile$data$pheno[,phenoDTfile$metadata$pheno[which(phenoDTfile$metadata$pheno$parameter == "environment"),"value"]])
   traitUsed <- unique(phenoDTfile$metadata$pheno[which( phenoDTfile$metadata$pheno$parameter == "trait"),"value"])
   
   pred <- phenoDTfile$predictions
@@ -51,7 +54,7 @@ postmetLMMsolver <- function(phenoDTfile= NULL, analysisId=NULL,
       if(any(grepl(":designation|designation:", gxeTerms))){
         gxeTermsF <- gxeTerms[which(grepl(":designation|designation:", gxeTerms))]
         for(j in 1:length(envUsed)){
-          pred[which(pred$analysisId == analysisId & pred$effectType %in% gxeTermsF & grepl(envUsed[j], pred$designation)),"environment"] <- envUsed[j]
+          pred[which(pred$analysisId == analysisId & pred$effectType %in% gxeTermsF & grepl(gsub("[^[:alnum:]]", "", envUsed[j]), pred$designation)),"environment"] <- envUsed[j]
         }
       }
     }


### PR DESCRIPTION
remove non alpha numeric characters in env name when used as model parameter to avoid having issues

example:
<img width="1072" height="281" alt="image" src="https://github.com/user-attachments/assets/18595a57-8df9-4c72-b0a4-b0d9ec0a7cd2" />