### PR TITLE
handle changes in environment name

### DIFF
--- a/R/nasaPowerExtraction.R
+++ b/R/nasaPowerExtraction.R
@@ -205,9 +205,9 @@ summaryWeather <- function(object, wide=FALSE){
                        timevar = "tp", v.names = "value", sep= "_")
     rownames(out) <- out$environment
     if(nrow(out) > 1){
-      Z = model.matrix(~environment-1, data=out); colnames(Z) <- gsub("ironment","",colnames(Z))
+      Z = model.matrix(~environment-1, data=out); colnames(Z) <- gsub("environment","",colnames(Z))
     }else{
-      Z <- matrix(1,1,1); colnames(Z) <- paste0("env",out$environment)
+      Z <- matrix(1,1,1); colnames(Z) <- out$environment
     }
 
     out <- cbind(out,Z)

--- a/R/prepostmetLMMsolver.R
+++ b/R/prepostmetLMMsolver.R
@@ -5,8 +5,8 @@ premetLMMsolver <- function(phenoDTfile= NULL, fixedTerm= NULL, randomTerm=NULL)
   
   gxeList <- list("gxeCS" = c("environment_designation", "designation_environment",
                               "environment:designation", "designation:environment"),
-                  "gxeDMD" = c(paste0("env",envUsed,"_designation"), paste0("designation_env",envUsed),
-                               paste0("env",envUsed,":designation"), paste0("designation:env",envUsed)),
+                  "gxeDMD" = c(paste0(envUsed,"_designation"), paste0("designation_",envUsed),
+                               paste0(envUsed,":designation"), paste0("designation:",envUsed)),
                   "gxeFW" = c(paste0("value_",traitUsed,"envIndex_designation"),paste0("designation_value_",traitUsed,"envIndex"),
                               paste0("value_",traitUsed,"envIndex:designation"),paste0("designation:value_",traitUsed,"envIndex")))
   
@@ -47,9 +47,16 @@ postmetLMMsolver <- function(phenoDTfile= NULL, analysisId=NULL,
       for (i in 1:length(traitUsed)){
         pred[which(pred$analysisId == analysisId & pred$effectType %in% gxeTerms & pred$trait == traitUsed[i]),"predictedValue"] <- pred[which(pred$analysisId == analysisId & pred$effectType %in% gxeTerms & pred$trait == traitUsed[i]),"predictedValue"] - pred[which(pred$analysisId == analysisId & pred$effectType == "(Intercept)" & pred$trait == traitUsed[i]),"predictedValue"]
       }
-    }else {
+    }else if(gxeModelNum == 1){
       if(any(grepl(":designation|designation:", gxeTerms))){
         gxeTermsF <- gxeTerms[which(grepl(":designation|designation:", gxeTerms))]
+        for(j in 1:length(envUsed)){
+          pred[which(pred$analysisId == analysisId & pred$effectType %in% gxeTermsF & grepl(envUsed[j], pred$designation)),"environment"] <- envUsed[j]
+        }
+      }
+    } else if(gxeModelNum == 2){
+      if(any(grepl(":designation|designation:|_designation|designation_", gxeTerms))){
+        gxeTermsF <- gxeTerms[which(grepl(":designation|designation:|_designation|designation_", gxeTerms))]
         for(j in 1:length(envUsed)){
           pred[which(pred$analysisId == analysisId & pred$effectType %in% gxeTermsF & grepl(envUsed[j], pred$designation)),"environment"] <- envUsed[j]
         }


### PR DESCRIPTION
As per suggestion of Khaled, we change how the environment is being formed to avoid having error in the model. To handle that change, these functions were modified.

**nasaPowerExtraction**
- no need to add "env" in front of the environment value (already added when the environment value is computed)

**prepostmetLMMsolver**
- removed "env" because it is already part of the environment value
- noticed that in the predictions table, the environment value of the interactions for other models is (Intercept), changed it to the environment value for generation of plots 